### PR TITLE
Remove outdated references on homepage

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,13 +21,9 @@
         <li><a href="/">Home</a></li>
         <li><a href="http://groups.google.com/forum/#!forum/urug"  target="_blank">Mailing List</a></li>
         <li><a href="http://www.meetup.com/Utah-Ruby-Users-Group/" target="_blank">Meetup Group</a></li>
-        <li><a href="/posts">Posts</a></li>
         <li><a href="/users">Users</a></li>
-        <li><a href="/lunches">Lunches</a></li>
-        <li><a href="/sponsors">Sponsors</a></li>
         <li><a href="http://github.com/urug" target="_blank">GitHub</a></li>
         <li><a href="http://urug.herokuapp.com/" target="_blank">Slack</a></li>
-        <li><a href="/companies">Companies</a></li>
     </ul>
   </nav>
 

--- a/index.html
+++ b/index.html
@@ -21,26 +21,8 @@ Sandy, UT</p>
 370 S 300 E <br>
 Salt Lake City, UT 84111</p>
 
-<h2 id="uv.rb">Utah Valley Ruby Brigade (uv.rb)</h2>
-<p>2nd Tuesday of the month at 7 PM<br>
-Somewhere with fast internet.<br>
-South of the point<br>
-Details & RSVP on the <a href="http://www.meetup.com/Utah-Ruby-Users-Group" target="_blank">URUG Meetup Page</a>
-
-<h2 id="layton.rb">Layton Ruby Brigade (layton.rb)</h2>
-<p>3rd Tuesday of the month at 7 PM<br>
-Manuel's El Burrito (<a href="http://goo.gl/maps/MLrUZ">map</a>)<br>
-1145 S State Street<br>
-Clearfield, UT 84015</p>
-
-<h2 id="logon.rb">Logan Ruby Brigade (logan.rb)</h2>
+<h2 id="logan.rb">Logan Ruby Brigade (logan.rb)</h2>
 <p>2nd Tuesday of every month at lunch. The location is announced on the <a href="http://groups.google.com/group/loganrb">Logan.rb list</a>.</p>
-
-<h2 id="stgeorge.rb">St. George Ruby Brigade (stgeorge.rb)</h2>
-<p>1st Wednesday of the month at 7:00 PM<br>
-University Plaza<br>
-1071 East 100 South, Building C, room C5<br>
-St. George, UT 84770</p>
 
 <h1>How do I join?</h1>
 <p>URUG membership incurs no dues, no fees, and no obligation. Just <a href="http://groups.google.com/forum/#!forum/urug">join the mailing list</a>, show up to the meetings periodically, and you're welcome to call yourself a member of the URUG. Its so easy to interact with other professional and hobby Rubyists in your area you'll kick yourself for not doing it sooner!</p>


### PR DESCRIPTION
This removes menu items pointing at now dead resources and
removes the listings for meetups that are currently inactive.